### PR TITLE
External source maps

### DIFF
--- a/tasks/pleeease.js
+++ b/tasks/pleeease.js
@@ -18,6 +18,7 @@ module.exports = function (grunt) {
 
         var result = pleeease.process(grunt.file.read(file), options);
         grunt.file.write(dest, result.css || result);
+        if (typeof result.map !== 'undefined') grunt.file.write(dest+'.map', result.map);
       });
 
       next();


### PR DESCRIPTION
I've fixed the pleeease task to write the source map to an external file if the option `inline: false` is entered.

I've also noticed that to get this to work, I still had to specifiy the `in` and `out` css files.

Here's a copy of my `pleeease` `initConfig` section:

```javascript
[...]
		pleeease: {
			dist: {
				options: {
					autoprefixer: {'browsers': ['last 2 versions', 'ie 9', 'ie 10']},
					in: 'build/styles/styles.css',
					out: 'public/styles/styles.min.css',
					sourcemaps: {
						map: {
							inline: false,
							sourcesContent: true
						}
					}
				},
				files: {
					'public/styles/styles.min.css': 'build/styles/styles.css'
				}
			}
		},
[...]
```